### PR TITLE
Fix cron

### DIFF
--- a/letsencrypt/Dockerfile
+++ b/letsencrypt/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx
 
-RUN apt-get update && apt-get install -y git wget cron
+RUN apt-get update && apt-get install -y git wget cron rsyslog
 
 RUN mkdir -p /letsencrypt/challenges/.well-known/acme-challenge
 RUN git clone https://github.com/letsencrypt/letsencrypt /letsencrypt/app

--- a/letsencrypt/Dockerfile
+++ b/letsencrypt/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx
 
-RUN apt-get update && apt-get install -y git wget cron rsyslog
+RUN apt-get update && apt-get install -y git wget cron
 
 RUN mkdir -p /letsencrypt/challenges/.well-known/acme-challenge
 RUN git clone https://github.com/letsencrypt/letsencrypt /letsencrypt/app

--- a/letsencrypt/README.md
+++ b/letsencrypt/README.md
@@ -37,3 +37,4 @@ kubectl exec -it <container> /bin/bash -- -c 'DOMAINS=example.com foo.example.co
      https://acme-staging.api.letsencrypt.org/directory
  - RC_NAMES - a space separated list of RC's whose pods to destroy after a
    certificate save.
+ - SECRET_NAME - the name to save the secrets under

--- a/letsencrypt/fetch_certs.sh
+++ b/letsencrypt/fetch_certs.sh
@@ -20,7 +20,7 @@ do
    # do whatever on $i
 done
 
-letsencrypt certonly \
+/usr/local/bin/letsencrypt certonly \
     --webroot -w /letsencrypt/challenges/ \
     --text --renew-by-default --agree-tos \
       $domain_args \

--- a/letsencrypt/refresh_certs.sh
+++ b/letsencrypt/refresh_certs.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+echo "$(date) Fetching certs..."
 /letsencrypt/fetch_certs.sh
+
+echo "$(date) Saving certs..."
 /letsencrypt/save_certs.sh
+
+echo "$(date) Recreating pods..."
 /letsencrypt/recreate_pods.sh

--- a/letsencrypt/refresh_certs.sh
+++ b/letsencrypt/refresh_certs.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -e
 
+if [ -e "/tmp/.letsencrypt-lock" ]
+then
+    echo "Nope, not gonna touch that."
+    exit 1
+fi
+
+touch /tmp/.letsencrypt-lock
+
 echo "$(date) Fetching certs..."
 /letsencrypt/fetch_certs.sh
 
@@ -9,3 +17,5 @@ echo "$(date) Saving certs..."
 
 echo "$(date) Recreating pods..."
 /letsencrypt/recreate_pods.sh
+
+rm /tmp/.letsencrypt-lock

--- a/letsencrypt/save_certs.sh
+++ b/letsencrypt/save_certs.sh
@@ -10,6 +10,11 @@
 # We want to convert fullchain.pem into proxycert
 # and privkey.pem into proxykey and then save as a secret!
 
+if [ -z "$SECRET_NAME" ]; then
+    echo "ERROR: Secret name is empty or unset"
+    exit 1
+fi
+
 CERT_LOCATION='/etc/letsencrypt/live'
 
 DOMAINS=($DOMAINS)
@@ -19,7 +24,6 @@ DOMAIN=${DOMAINS[0]}
 CERT=$(cat $CERT_LOCATION/$DOMAIN/fullchain.pem | base64 --wrap=0)
 KEY=$(cat $CERT_LOCATION/$DOMAIN/privkey.pem | base64 --wrap=0)
 DHPARAM=$(openssl dhparam 2048 | base64 --wrap=0)
-SECRET_NAME="certs-${DOMAIN}"
 
 kubectl get secrets $SECRET_NAME && ACTION=replace || ACTION=create;
 

--- a/letsencrypt/start.sh
+++ b/letsencrypt/start.sh
@@ -8,7 +8,7 @@ echo "EMAIL: " $EMAIL
 echo "RC_NAMES: " $RC_NAMES
 # On the first of each month at midnight, fetch and save certs + restart pods.
 
-line="0 0 1 * * RC_NAMES='$RC_NAMES' DOMAINS='$DOMAINS' EMAIL=$EMAIL /letsencrypt/refresh_certs.sh"
+line="0 0 1 * * RC_NAMES='$RC_NAMES' DOMAINS='$DOMAINS' EMAIL=$EMAIL /letsencrypt/refresh_certs.sh >> /var/log/cron-encrypt.log"
 (crontab -u root -l; echo "$line" ) | crontab -u root -
 
 
@@ -18,6 +18,8 @@ fi
 
 # Start cron
 echo "Starting cron..."
+touch /var/log/cron.log
+rsyslogd
 cron &
 
 echo "Starting nginx..."

--- a/letsencrypt/start.sh
+++ b/letsencrypt/start.sh
@@ -6,11 +6,14 @@ echo "Configuring cron..."
 echo "DOMAINS: " $DOMAINS
 echo "EMAIL: " $EMAIL
 echo "RC_NAMES: " $RC_NAMES
+echo "SECRET_NAME: " $SECRET_NAME
 # On the first of each month at midnight, fetch and save certs + restart pods.
 
-line="0 0 1 * * RC_NAMES='$RC_NAMES' DOMAINS='$DOMAINS' EMAIL=$EMAIL /letsencrypt/refresh_certs.sh >> /var/log/cron-encrypt.log"
-(crontab -u root -l; echo "$line" ) | crontab -u root -
+# The process running under cron needs to know where the to find the kubernetes api
+env_vars="PATH=$PATH KUBERNETES_PORT=$KUBERNETES_PORT KUBERNETES_PORT_443_TCP_PORT=$KUBERNETES_PORT_443_TCP_PORT KUBERNETES_SERVICE_PORT=$KUBERNETES_SERVICE_PORT KUBERNETES_SERVICE_HOST=$KUBERNETES_SERVICE_HOST KUBERNETES_PORT_443_TCP_PROTO=$KUBERNETES_PORT_443_TCP_PROTO KUBERNETES_PORT_443_TCP_ADDR=$KUBERNETES_PORT_443_TCP_ADDR KUBERNETES_PORT_443_TCP=$KUBERNETES_PORT_443_TCP"
 
+line="0 0 1 * * $env_vars SECRET_NAME=$SECRET_NAME RC_NAMES='$RC_NAMES' DOMAINS='$DOMAINS' EMAIL=$EMAIL /bin/bash /letsencrypt/refresh_certs.sh >> /var/log/cron-encrypt.log 2>&1"
+(crontab -u root -l; echo "$line" ) | crontab -u root -
 
 if [ -n "${LETSENCRYPT_ENDPOINT+1}" ]; then
     echo "server = $LETSENCRYPT_ENDPOINT" >> /etc/letsencrypt/cli.ini
@@ -18,8 +21,6 @@ fi
 
 # Start cron
 echo "Starting cron..."
-touch /var/log/cron.log
-rsyslogd
 cron &
 
 echo "Starting nginx..."


### PR DESCRIPTION
Next time I'm in the space I'll create a new repo for each of these public docker images to declutter.

This PR makes cron actually work:

 - $PATH was incorrect within a cron run, so kubectl couldn't be found
 - All the Kubernetes settings that seem to be added automatically when connecting via `kubectl exec` are not present in the cron run.

I tested it and it worked